### PR TITLE
Add doxygen/breathe support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN pip3 install -r requirements.txt
 RUN apt-get update \
     && apt-get install -y \
           git \
+          doxygen \
+          graphiz \
     && apt-get autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 sphinx_rtd_theme
-breathe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sphinx_rtd_theme
+breathe


### PR DESCRIPTION
Add doxygen and graphiz to apt installs and breathe to pip3 install so that doxygen and breathe can be used

This is to address [#332](https://github.com/ros-controls/ros2_control/issues/332)